### PR TITLE
update imagemagick version

### DIFF
--- a/graalvm-alfresco-repository/pom.xml
+++ b/graalvm-alfresco-repository/pom.xml
@@ -14,7 +14,7 @@
         <docker.from.name>baseimage-graalvm-tomcat8</docker.from.name>
         <docker.from.version>1.0.0-SNAPSHOT</docker.from.version>
 
-        <imagemagick.version>7.0.8-11</imagemagick.version>
+        <imagemagick.version>7.0.8-25</imagemagick.version>
     </properties>
 
     <dependencies>

--- a/jdk8-alfresco-repository/pom.xml
+++ b/jdk8-alfresco-repository/pom.xml
@@ -14,7 +14,7 @@
         <docker.from.name>baseimage-jdk8-tomcat8</docker.from.name>
         <docker.from.version>1.0.0-SNAPSHOT</docker.from.version>
 
-        <imagemagick.version>7.0.8-11</imagemagick.version>
+        <imagemagick.version>7.0.8-25</imagemagick.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
The old version of ImageMagick (7.0.8-11) does not exist anymore on their "download" page. Update to version 7.0.8-25 required to successfully build this project.