### PR TITLE
update ImageMagick version + fix admin pwd

### DIFF
--- a/openjdk8-alfresco-repository/src/main/resources/initAlfresco.sh
+++ b/openjdk8-alfresco-repository/src/main/resources/initAlfresco.sh
@@ -153,7 +153,7 @@ then
    sed -i "s/%DB_USER%/${DB_USER}/g" /srv/alfresco/config/alfresco-global.properties
    sed -i "s/%DB_PW%/${DB_PW}/g" /srv/alfresco/config/alfresco-global.properties
 
-   ALFRESCO_ADMIN_PASSWORD=`printf '%s' "$ALFRESCO_ADMIN_PASSWORD" | iconv -t utf16le | openssl md4`
+   ALFRESCO_ADMIN_PASSWORD=`printf '%s' "$ALFRESCO_ADMIN_PASSWORD" | iconv -t utf16le | openssl md4 | cut -d' ' -f2`
    sed -i "s/%ADMIN_PW%/${ALFRESCO_ADMIN_PASSWORD}/g" /srv/alfresco/config/alfresco-global.properties
 
    sed -i "s/%SEARCH_SUBSYSTEM%/${SEARCH_SUBSYSTEM}/g" /srv/alfresco/config/alfresco-global.properties

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <docker.labels.namespace>de.acosix.docker.alfresco</docker.labels.namespace>
 
-        <imagemagick.version>7.0.8-33</imagemagick.version>
+        <imagemagick.version>7.0.8-44</imagemagick.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
The current command to generate the MD4 hash of the Alfresco admin password outputs
`(stdin)= <MD4_HASH>`, whereas it should be `<MD4_HASH>` so I propose to use `cut` to use the part after the space token.

Also updated the ImageMagick version.