### PR TITLE
Fix: always assign a value when processing env vars in initShare.sh

### DIFF
--- a/basic-images/alfresco-share-java11/src/main/resources/initShare.sh
+++ b/basic-images/alfresco-share-java11/src/main/resources/initShare.sh
@@ -170,6 +170,8 @@ then
    IFS=$'\n'
    for i in `env`
    do
+      value=`echo "$i" | cut -d '=' -f 2-`
+
       if [[ $i == GLOBAL_* && -f '/srv/alfresco/config/share-global.properties' ]]
       then
          echo "Processing environment variable $i" > /proc/1/fd/1

--- a/basic-images/alfresco-share-java8/src/main/resources/initShare.sh
+++ b/basic-images/alfresco-share-java8/src/main/resources/initShare.sh
@@ -170,6 +170,8 @@ then
    IFS=$'\n'
    for i in `env`
    do
+      value=`echo "$i" | cut -d '=' -f 2-`
+
       if [[ $i == GLOBAL_* && -f '/srv/alfresco/config/share-global.properties' ]]
       then
          echo "Processing environment variable $i" > /proc/1/fd/1


### PR DESCRIPTION
This fixes an issue I had when trying to patch values in share-global.properties via environment variables.
Similarly as in initAlfresco.sh for the repo image, a value is always assigned first before moving on to the if statements.